### PR TITLE
Generate performance test html based on platform to run (desktop or mobile)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,7 @@ component = { /* see https://github.com/component/component/wiki/Spec for a desc
     files: [],
 },
     _ = require('underscore'),
+    os = require('os'),
     fs = require('fs'),
     path = require('path'),
     chromiumSrc = process.env.CHROMIUM_SRC;
@@ -101,7 +102,8 @@ module.exports = function(grunt) {
                 options: {
                     data: {
                         debug: false,
-                        pretty: true
+                        pretty: true,
+                        target: os.platform() == 'linux' ? 'mobile' : 'desktop'
                     }
                 },
                 files: [{ //todo see if expandMapping can be used instead of listing them all - https://github.com/gruntjs/grunt-contrib/issues/95

--- a/test/perf/telemetry/perf/page_sets/topcoat/topcoat_buttons.jade
+++ b/test/perf/telemetry/perf/page_sets/topcoat/topcoat_buttons.jade
@@ -1,10 +1,29 @@
--var repeats = 200
+repeats     = 200
+button      = target == "desktop" ? "button" : "light-button"
+quietButton = target == "desktop" ? "quiet"  : "quiet-button"
+largeButton = target == "desktop" ? "large"  : "large-button"
+
 !!!
 html
     head
         title TopCoat buttons test
-        |<link rel="stylesheet" type="text/css" href="./release/css/topcoat-desktop-min.css">
+        <link rel="stylesheet" type="text/css" href=./release/css/topcoat-#{target}-min.css>
     body
         -while (repeats > 0)
             -var repeats = repeats - 1
-            include buttons.html
+
+            table.preview(role='presentation')
+                tr(role='presentation')
+                    td(role='presentation')
+                        p
+                            a(class='#{button}', href='#button', role='button') Button
+                            a(class='#{button} disabled', role='button', aria-disabled='true') Disabled Button
+                        p
+                            a(class="#{button} #{quietButton}", href='#button', role='button') Quiet Button
+                            a(class="#{button} #{quietButton} disabled", role='button', aria-disabled='true') Disabled Quiet Button
+                        p
+                            a(class="#{button} #{largeButton}", href='#button', role='button') Large Button
+                            a(class="#{button} #{largeButton} disabled", role='button', aria-disabled='true') Large Disabled Button
+                        p
+                            a(class="#{button} #{quietButton} #{largeButton}", href='#button', role='button') Quiet Button
+                            a(class="#{button} #{quietButton} #{largeButton} disabled", role='button', aria-disabled='true') Disabled Quiet Button


### PR DESCRIPTION
In the this implementation, I use the platform on which Telemetry test runs to tell wether to use desktop or mobile css. Because at this point, mobile Telemetry test has to be ran on Linux so we can just use "linux" as the indicator for mobile run.

Or we can add another environment variable to do that too. But that's one more env var to set :-)

Tested on Mac and Ubuntu.
