### PR TITLE
updating gitignore to ignore src/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ node_modules
 npm-debug.log
 tmp
 .DS_Store
-src/controls/*
-src/theme/*
+src/
 .tern-port


### PR DESCRIPTION
After doing "grunt" the src/ was an untracked.  current .gitignore only ignores some of the src directory
