### PR TITLE
Updating README.md to use latest version for "Download Topcoat"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CSS for clean and fast web apps
 
 ## Usage
 
-* [Download Topcoat](https://github.com/topcoat/topcoat/archive/0.5.1.zip)
+* [Download Topcoat](https://github.com/topcoat/topcoat/archive/0.6.0.zip)
 
 * Open index.html to view the usage guides.
 * Copy your desired theme CSS from the `css/` folder into your project


### PR DESCRIPTION
Download Topcoat was pointing to version 5.1, fixed to point to latest 6.0
