### PR TITLE
added travis test check

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -187,6 +187,15 @@ module.exports = function(grunt) {
             }
         },
 
+        simplemocha: {
+            all: {
+                src: ['test/*.test.js']
+            },
+            options: {
+                timeout: 5000
+            }
+        },
+
         watch: {
             files: ['src/**/*.styl'],
             tasks: ['compile']
@@ -204,6 +213,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-topdoc');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
     grunt.loadNpmTasks('grunt-contrib-htmlmin');
+    grunt.loadNpmTasks('grunt-simple-mocha');
 
     //Load local tasks
     grunt.loadTasks('dev/tasks');

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "grunt-contrib-stylus": "~0.6.0",
     "grunt-contrib-htmlmin": "~0.1.3",
     "prompt": "*",
-    "csv": "*"
+    "csv": "*",
+    "grunt-simple-mocha": "~0.4.0"
   },
   "scripts": {
     "test": "grunt test",

--- a/test/topcoat.test.js
+++ b/test/topcoat.test.js
@@ -1,0 +1,67 @@
+/**
+*
+* Copyright 2012 Adobe Systems Inc.;
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+/*global require, describe, it*/
+
+var grunt = require('grunt'),
+    assert = require('assert'),
+    request = require('request');
+
+var deps = {
+    "topcoat-utils": "~0.1.3",
+    "topcoat-radio-button-base": "~0.1.1",
+    "topcoat-checkbox-base": "~0.1.3",
+    "topcoat-input-base": "~0.3.0",
+    "topcoat-textarea-base": "~0.2.0",
+    "topcoat-button-base": "~0.6.0",
+    "topcoat-list-base": "~0.3.0",
+    "topcoat-checkbox": "~0.3.4",
+    "topcoat-radio-button": "~0.1.1",
+    "topcoat-theme": "~0.5.4",
+    "topcoat-list": "~0.4.0",
+    "topcoat-navigation-bar-base": "~0.4.0",
+    "topcoat-navigation-bar": "~0.4.0",
+    "topcoat-button": "~0.5.0",
+    "topcoat-search-input": "~0.2.0",
+    "topcoat-textarea": "~0.2.0",
+    "topcoat-text-input": "~0.3.0"
+  }
+
+var travis = 'https://travis-ci.org/topcoat/';
+
+describe('Topcoat', function() {
+    'use strict';
+
+    for (var i in deps) {
+
+        var repo = i.substring(8,i.length);
+
+        it(repo + ' should pass', function(done) {
+
+            request.get({url: travis + repo + '.json', json: true}, function (err, resp, body) {
+                if (err) throw err;
+                if (body.last_build_result != 0) throw new Error(repo + ' build failed');
+                done();
+            });
+
+        });
+        
+    }
+
+});
+


### PR DESCRIPTION
_@GarthDB always said we don't have a test for the main Topcoat repo_

I wrote a quick test that fetches the json status file of all the components and checks if it was successful. It could be further improved like read directly from the package.json, I just wanted to show it for opinions.  
![screen shot 2013-08-29 at 4 16 29 pm](https://f.cloud.github.com/assets/810040/1049740/93f5b1d6-10ad-11e3-90fb-a945b549680b.png)

It's really slow as you can see 54 seconds so I don't recommend it being part of the default task but useful before publishing imo. Thoughts ?
