### PR TITLE
make Gruntfile more DRY

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,20 +131,10 @@ module.exports = function(grunt) {
                      */
                 },
                 files: [{
-                    src: 'css/topcoat-desktop-dark.css',
-                    dest: 'css/topcoat-desktop-dark.css'
-                },
-                {
-                    src: 'css/topcoat-desktop-light.css',
-                    dest: 'css/topcoat-desktop-light.css'
-                },
-                {
-                    src: 'css/topcoat-mobile-dark.css',
-                    dest: 'css/topcoat-mobile-dark.css'
-                },
-                {
-                    src: 'css/topcoat-mobile-light.css',
-                    dest: 'css/topcoat-mobile-light.css'
+                    expand: true,
+                    cwd: 'css',
+                    src: ['*.css', '!*.min.css'],
+                    dest: 'css/'
                 }]
             }
 


### PR DESCRIPTION
make the autoprefixer config use a glob syntax to make adding new themes more easy
